### PR TITLE
Fix/hls-playback

### DIFF
--- a/internal/playback/on_get.go
+++ b/internal/playback/on_get.go
@@ -1,6 +1,7 @@
 package playback
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -13,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/bluenviron/mediacommon/v2/pkg/formats/fmp4"
@@ -212,7 +214,8 @@ func (s *Server) onGet(ctx *gin.Context) {
 // handles HLS playback flow.
 func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, duration time.Duration, pathConf *conf.Path, segments []*recordstore.Segment) {
 	s.Log(logger.Info, "request for hls")
-	token := computeToken(ctx.ClientIP(), pathName, start, duration)
+	clientIP := ctx.ClientIP()
+	token := computeToken(clientIP, pathName, start, duration)
 	hlsDir := filepath.Join(".", "mediamtx_hls", token)
 
 	if segFile := ctx.Query("file"); segFile != "" {
@@ -229,8 +232,11 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 
 	errChan := make(chan error, 1)
 
+	cmdCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	go func() {
-		var err error
+		var ffmpegArgs []string
 
 		if pathConf.RecordFormat == conf.RecordFormatMPEGTS {
 			listPath := filepath.Join(hlsDir, "list.txt")
@@ -246,7 +252,7 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 			}
 
 			startOffset := start.Sub(segments[0].Start)
-			ffmpegArgs := []string{
+			ffmpegArgs = []string{
 				"-y",
 				"-f", "concat",
 				"-safe", "0",
@@ -259,8 +265,6 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 				"-hls_list_size", "0",
 				hlsPlaylist,
 			}
-
-			err = exec.Command("ffmpeg", ffmpegArgs...).Run()
 		} else {
 			trimmedFilePath := filepath.Join(hlsDir, "trimmed.mp4")
 			f, ferr := os.Create(trimmedFilePath)
@@ -276,7 +280,7 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 				return
 			}
 
-			ffmpegArgs := []string{
+			ffmpegArgs = []string{
 				"-y",
 				"-i", trimmedFilePath,
 				"-c", "copy",
@@ -286,9 +290,18 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 				"-hls_base_url", "",
 				hlsPlaylist,
 			}
-			err = exec.Command("ffmpeg", ffmpegArgs...).Run()
 		}
 
+		cmd := exec.CommandContext(cmdCtx, "ffmpeg", ffmpegArgs...)
+
+		if err := cmd.Start(); err != nil {
+			errChan <- fmt.Errorf("ffmpeg start failed: %w", err)
+			return
+		}
+
+		s.addHLSPid(clientIP, cmd.Process.Pid)
+		err := cmd.Wait()
+		defer s.removeHLSPid(clientIP, cmd.Process.Pid)
 		errChan <- err
 	}()
 
@@ -326,4 +339,28 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 	}
 	ctx.Header("Content-Type", "application/vnd.apple.mpegurl")
 	ctx.String(http.StatusOK, strings.Join(rewrittenLines, "\n"))
+}
+
+func (s *Server) onKillHls(ctx *gin.Context) {
+	clientIP := ctx.ClientIP()
+	pids := s.getAndClearHLSPids(clientIP)
+	if len(pids) == 0 {
+		ctx.JSON(http.StatusOK, gin.H{"message": "no HLS process to kill for this client IP"})
+		return
+	}
+
+	var errs []string
+	for _, pid := range pids {
+		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+			errs = append(errs, fmt.Sprintf("pid %d: %v", pid, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errs})
+		return
+	} else {
+		ctx.JSON(http.StatusOK, gin.H{"message": "all HLS processes killed 🛑"})
+		return
+	}
 }

--- a/internal/playback/on_get.go
+++ b/internal/playback/on_get.go
@@ -227,82 +227,77 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 		s.writeError(ctx, http.StatusInternalServerError, fmt.Errorf("failed to create HLS directory: %w", err))
 		return
 	}
-
 	hlsPlaylist := filepath.Join(hlsDir, "index.m3u8")
 
-	errChan := make(chan error, 1)
+	var ffmpegArgs []string
+	if pathConf.RecordFormat == conf.RecordFormatMPEGTS {
+		listPath := filepath.Join(hlsDir, "list.txt")
+		listFile, lerr := os.Create(listPath)
+		if lerr != nil {
+			s.writeError(ctx, http.StatusInternalServerError, fmt.Errorf("failed to create list file: %w", lerr))
+			return
+		}
+		defer listFile.Close()
 
+		for _, seg := range segments {
+			fmt.Fprintf(listFile, "file '%s'\n", seg.Fpath)
+		}
+
+		startOffset := start.Sub(segments[0].Start)
+		ffmpegArgs = []string{
+			"-n",
+			"-y",
+			"-f", "concat",
+			"-safe", "0",
+			"-i", listPath,
+			"-ss", fmt.Sprintf("%.2f", startOffset.Seconds()),
+			"-t", fmt.Sprintf("%.2f", duration.Seconds()),
+			"-c", "copy",
+			"-f", "hls",
+			"-hls_time", "10",
+			"-hls_list_size", "0",
+			hlsPlaylist,
+		}
+	} else {
+		trimmedFilePath := filepath.Join(hlsDir, "trimmed.mp4")
+		f, ferr := os.Create(trimmedFilePath)
+		if ferr != nil {
+			s.writeError(ctx, http.StatusInternalServerError, fmt.Errorf("failed to create trimmed file: %w", ferr))
+			return
+		}
+		m := &muxerFMP4{w: f}
+		if muxErr := seekAndMux(pathConf.RecordFormat, segments, start, duration, m); muxErr != nil {
+			f.Close()
+			s.writeError(ctx, http.StatusInternalServerError, fmt.Errorf("muxing failed: %w", muxErr))
+			return
+		}
+		f.Close()
+
+		ffmpegArgs = []string{
+			"-y",
+			"-i", trimmedFilePath,
+			"-c", "copy",
+			"-f", "hls",
+			"-hls_time", "10",
+			"-hls_list_size", "0",
+			"-hls_base_url", "",
+			hlsPlaylist,
+		}
+	}
+
+	errChan := make(chan error, 1)
 	cmdCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	go func() {
-		var ffmpegArgs []string
-
-		if pathConf.RecordFormat == conf.RecordFormatMPEGTS {
-			listPath := filepath.Join(hlsDir, "list.txt")
-			listFile, lerr := os.Create(listPath)
-			if lerr != nil {
-				errChan <- fmt.Errorf("failed to create list file: %w", lerr)
-				return
-			}
-			defer listFile.Close()
-
-			for _, seg := range segments {
-				fmt.Fprintf(listFile, "file '%s'\n", seg.Fpath)
-			}
-
-			startOffset := start.Sub(segments[0].Start)
-			ffmpegArgs = []string{
-				"-y",
-				"-f", "concat",
-				"-safe", "0",
-				"-i", listPath,
-				"-ss", fmt.Sprintf("%.2f", startOffset.Seconds()),
-				"-t", fmt.Sprintf("%.2f", duration.Seconds()),
-				"-c", "copy",
-				"-f", "hls",
-				"-hls_time", "10",
-				"-hls_list_size", "0",
-				hlsPlaylist,
-			}
-		} else {
-			trimmedFilePath := filepath.Join(hlsDir, "trimmed.mp4")
-			f, ferr := os.Create(trimmedFilePath)
-			if ferr != nil {
-				errChan <- fmt.Errorf("failed to create trimmed file: %w", ferr)
-				return
-			}
-			m := &muxerFMP4{w: f}
-			muxErr := seekAndMux(pathConf.RecordFormat, segments, start, duration, m)
-			f.Close()
-			if muxErr != nil {
-				errChan <- fmt.Errorf("muxing failed: %w", muxErr)
-				return
-			}
-
-			ffmpegArgs = []string{
-				"-y",
-				"-i", trimmedFilePath,
-				"-c", "copy",
-				"-f", "hls",
-				"-hls_time", "10",
-				"-hls_list_size", "0",
-				"-hls_base_url", "",
-				hlsPlaylist,
-			}
-		}
-
 		cmd := exec.CommandContext(cmdCtx, "ffmpeg", ffmpegArgs...)
-
 		if err := cmd.Start(); err != nil {
 			errChan <- fmt.Errorf("ffmpeg start failed: %w", err)
 			return
 		}
-
 		s.addHLSPid(clientIP, cmd.Process.Pid)
-		err := cmd.Wait()
-		defer s.removeHLSPid(clientIP, cmd.Process.Pid)
-		errChan <- err
+		errChan <- cmd.Wait()
+		s.removeHLSPid(clientIP, cmd.Process.Pid)
 	}()
 
 	// Wait for the processing to complete

--- a/internal/playback/on_get.go
+++ b/internal/playback/on_get.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/bluenviron/mediacommon/v2/pkg/formats/fmp4"
@@ -136,7 +135,6 @@ func (s *Server) onGet(ctx *gin.Context) {
 	}
 
 	startStr := ctx.Request.URL.Query().Get("start")
-	s.Log(logger.Info, "start param", startStr)
 	start, err := time.Parse(time.RFC3339, startStr)
 	if err != nil {
 		s.writeError(ctx, http.StatusBadRequest, fmt.Errorf("invalid start: %w", err))
@@ -211,23 +209,61 @@ func (s *Server) onGet(ctx *gin.Context) {
 	}
 }
 
+var ffmpegSem = make(chan struct{}, 16) // based on CPU cores
+
 // handles HLS playback flow.
 func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, duration time.Duration, pathConf *conf.Path, segments []*recordstore.Segment) {
-	s.Log(logger.Info, "request for hls")
 	clientIP := ctx.ClientIP()
 	token := computeToken(clientIP, pathName, start, duration)
 	hlsDir := filepath.Join(".", "mediamtx_hls", token)
+	hlsPlaylist := filepath.Join(hlsDir, "index.m3u8")
 
 	if segFile := ctx.Query("file"); segFile != "" {
 		ctx.File(filepath.Join(hlsDir, segFile))
 		return
 	}
 
+	s.Log(logger.Info, fmt.Sprintf("HLS request - path: %s, start: %s, duration: %s", pathName, start.Format(time.RFC3339), duration))
+	// Check for existing process and wait if present
+	s.activeHLSLock.Lock()
+	clientMap, exists := s.activeHLSTokens[clientIP]
+	if !exists {
+		clientMap = make(map[string]*HLSProcessInfo)
+		s.activeHLSTokens[clientIP] = clientMap
+	}
+	processInfo, exists := clientMap[token]
+	if exists {
+		s.activeHLSLock.Unlock()
+		select {
+		case <-processInfo.doneChan:
+			// // Existing process completed, check for segment file or serve playlist
+			// if segFile := ctx.Query("file"); segFile != "" {
+			// 	ctx.File(filepath.Join(hlsDir, segFile))
+			// 	return
+			// }
+			playlistBytes, err := os.ReadFile(hlsPlaylist)
+			if err != nil {
+				s.writeError(ctx, http.StatusInternalServerError, fmt.Errorf("failed to read playlist: %w", err))
+				return
+			}
+			servePlaylist(ctx, playlistBytes)
+			return
+		case <-ctx.Request.Context().Done():
+			return
+		}
+	} else {
+		// No existing process, create new entry
+		processInfo = &HLSProcessInfo{
+			doneChan: make(chan struct{}),
+		}
+		clientMap[token] = processInfo
+		s.activeHLSLock.Unlock()
+	}
+
 	if err := os.MkdirAll(hlsDir, 0755); err != nil {
 		s.writeError(ctx, http.StatusInternalServerError, fmt.Errorf("failed to create HLS directory: %w", err))
 		return
 	}
-	hlsPlaylist := filepath.Join(hlsDir, "index.m3u8")
 
 	var ffmpegArgs []string
 	if pathConf.RecordFormat == conf.RecordFormatMPEGTS {
@@ -245,8 +281,9 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 
 		startOffset := start.Sub(segments[0].Start)
 		ffmpegArgs = []string{
-			"-n",
 			"-y",
+			"-hwaccel", "auto",
+			"-threads", "4",
 			"-f", "concat",
 			"-safe", "0",
 			"-i", listPath,
@@ -290,17 +327,41 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 	defer cancel()
 
 	go func() {
+		// TODO: remove after test
+		ffmpegSem <- struct{}{}        // Acquire a slot
+		defer func() { <-ffmpegSem }() // Release the slot
+
+		startTime := time.Now()
 		cmd := exec.CommandContext(cmdCtx, "ffmpeg", ffmpegArgs...)
 		if err := cmd.Start(); err != nil {
 			errChan <- fmt.Errorf("ffmpeg start failed: %w", err)
 			return
 		}
-		s.addHLSPid(clientIP, cmd.Process.Pid)
-		errChan <- cmd.Wait()
-		s.removeHLSPid(clientIP, cmd.Process.Pid)
+
+		// Track PID
+		s.activeHLSLock.Lock()
+		processInfo.pid = cmd.Process.Pid
+		s.activeHLSLock.Unlock()
+
+		err := cmd.Wait()
+
+		// logger
+		executionTime := time.Since(startTime)
+		s.Log(logger.Info, fmt.Sprintf("ffmpeg completed for token %s, took %s", token, executionTime))
+
+		// Cleanup
+		s.activeHLSLock.Lock()
+		if cm, exists := s.activeHLSTokens[clientIP]; exists {
+			delete(cm, token)
+			if len(cm) == 0 {
+				delete(s.activeHLSTokens, clientIP)
+			}
+		}
+		s.activeHLSLock.Unlock()
+		close(processInfo.doneChan)
+		errChan <- err
 	}()
 
-	// Wait for the processing to complete
 	if err := <-errChan; err != nil {
 		s.writeError(ctx, http.StatusInternalServerError, fmt.Errorf("ffmpeg processing failed: %w", err))
 		return
@@ -311,9 +372,14 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 		s.writeError(ctx, http.StatusInternalServerError, fmt.Errorf("failed to read playlist: %w", err))
 		return
 	}
+	servePlaylist(ctx, playlistBytes)
+}
+
+// servePlaylist rewrites the playlist URLs and sends the response.
+func servePlaylist(ctx *gin.Context, playlistBytes []byte) {
 	playlistContent := string(playlistBytes)
 	if !strings.HasPrefix(playlistContent, "#EXTM3U") {
-		s.writeError(ctx, http.StatusInternalServerError, fmt.Errorf("invalid playlist generated"))
+		ctx.String(http.StatusInternalServerError, "invalid playlist generated")
 		return
 	}
 
@@ -337,25 +403,4 @@ func (s *Server) handleHLS(ctx *gin.Context, pathName string, start time.Time, d
 }
 
 func (s *Server) onKillHls(ctx *gin.Context) {
-	clientIP := ctx.ClientIP()
-	pids := s.getAndClearHLSPids(clientIP)
-	if len(pids) == 0 {
-		ctx.JSON(http.StatusOK, gin.H{"message": "no HLS process to kill for this client IP"})
-		return
-	}
-
-	var errs []string
-	for _, pid := range pids {
-		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
-			errs = append(errs, fmt.Sprintf("pid %d: %v", pid, err))
-		}
-	}
-
-	if len(errs) > 0 {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errs})
-		return
-	} else {
-		ctx.JSON(http.StatusOK, gin.H{"message": "all HLS processes killed 🛑"})
-		return
-	}
 }

--- a/internal/playback/server.go
+++ b/internal/playback/server.go
@@ -34,6 +34,41 @@ type Server struct {
 
 	httpServer *httpp.Server
 	mutex      sync.RWMutex
+
+	pidStore   map[string][]int
+	pidStoreMu sync.RWMutex
+}
+
+func (s *Server) addHLSPid(clientIP string, pid int) {
+	s.pidStoreMu.Lock()
+	defer s.pidStoreMu.Unlock()
+	s.pidStore[clientIP] = append(s.pidStore[clientIP], pid)
+}
+
+func (s *Server) getAndClearHLSPids(clientIP string) []int {
+	s.pidStoreMu.Lock()
+	defer s.pidStoreMu.Unlock()
+	pids := s.pidStore[clientIP]
+	delete(s.pidStore, clientIP)
+	return pids
+}
+
+func (s *Server) removeHLSPid(clientIP string, pid int) {
+	s.pidStoreMu.Lock()
+	defer s.pidStoreMu.Unlock()
+	pids, ok := s.pidStore[clientIP]
+	if !ok {
+		return
+	}
+	for i, p := range pids {
+		if p == pid {
+			s.pidStore[clientIP] = append(pids[:i], pids[i+1:]...)
+			break
+		}
+	}
+	if len(s.pidStore[clientIP]) == 0 {
+		delete(s.pidStore, clientIP)
+	}
 }
 
 // Initialize initializes Server.
@@ -45,6 +80,7 @@ func (s *Server) Initialize() error {
 
 	router.GET("/list", s.onList)
 	router.GET("/get", s.onGet)
+	router.GET("/killHLS", s.onKillHls)
 	router.DELETE("/hls", s.deleteHLSDir)
 
 	network, address := restrictnetwork.Restrict("tcp", s.Address)
@@ -59,6 +95,7 @@ func (s *Server) Initialize() error {
 		Handler:     router,
 		Parent:      s,
 	}
+	s.pidStore = make(map[string][]int)
 	err := s.httpServer.Initialize()
 	if err != nil {
 		return err

--- a/internal/playback/server.go
+++ b/internal/playback/server.go
@@ -19,6 +19,11 @@ type serverAuthManager interface {
 	Authenticate(req *auth.Request) error
 }
 
+type HLSProcessInfo struct {
+	doneChan chan struct{}
+	pid      int
+}
+
 // Server is the playback server.
 type Server struct {
 	Address        string
@@ -35,40 +40,8 @@ type Server struct {
 	httpServer *httpp.Server
 	mutex      sync.RWMutex
 
-	pidStore   map[string][]int
-	pidStoreMu sync.RWMutex
-}
-
-func (s *Server) addHLSPid(clientIP string, pid int) {
-	s.pidStoreMu.Lock()
-	defer s.pidStoreMu.Unlock()
-	s.pidStore[clientIP] = append(s.pidStore[clientIP], pid)
-}
-
-func (s *Server) getAndClearHLSPids(clientIP string) []int {
-	s.pidStoreMu.Lock()
-	defer s.pidStoreMu.Unlock()
-	pids := s.pidStore[clientIP]
-	delete(s.pidStore, clientIP)
-	return pids
-}
-
-func (s *Server) removeHLSPid(clientIP string, pid int) {
-	s.pidStoreMu.Lock()
-	defer s.pidStoreMu.Unlock()
-	pids, ok := s.pidStore[clientIP]
-	if !ok {
-		return
-	}
-	for i, p := range pids {
-		if p == pid {
-			s.pidStore[clientIP] = append(pids[:i], pids[i+1:]...)
-			break
-		}
-	}
-	if len(s.pidStore[clientIP]) == 0 {
-		delete(s.pidStore, clientIP)
-	}
+	activeHLSTokens map[string]map[string]*HLSProcessInfo // clientIP -> token -> HLSProcessInfo {doneChan & pid}
+	activeHLSLock   sync.RWMutex
 }
 
 // Initialize initializes Server.
@@ -95,7 +68,7 @@ func (s *Server) Initialize() error {
 		Handler:     router,
 		Parent:      s,
 	}
-	s.pidStore = make(map[string][]int)
+	s.activeHLSTokens = make(map[string]map[string]*HLSProcessInfo)
 	err := s.httpServer.Initialize()
 	if err != nil {
 		return err


### PR DESCRIPTION
1. introduced separate go routines for each hls conversion processses (with a threshold time to get auto-killed if exceeded)
2. added api endpoint to kill all hls processes